### PR TITLE
feat: support difference cache engines

### DIFF
--- a/.github/workflows/run-tests-on-push-or-pull-request.yaml
+++ b/.github/workflows/run-tests-on-push-or-pull-request.yaml
@@ -47,4 +47,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./package/coverage/lcov.info
+        files: ./package/coverage/lcov.info

--- a/package/jest.config.js
+++ b/package/jest.config.js
@@ -15,4 +15,6 @@ module.exports = {
       lines: 100,
     },
   },
+  // collectCoverage: true,
+  coverageReporters: ['json', 'lcov', 'text', 'clover'],
 };

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "@nestjs/common": "^9.4.0",
         "cache-manager": "^5.2.1",
+        "cache-manager-ioredis-yet": "^1.1.0",
         "json-stable-stringify": "^1.0.2",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
         "@golevelup/nestjs-testing": "^0.1.2",
+        "@golevelup/ts-jest": "^0.3.7",
         "@nestjs/testing": "^9.4.0",
         "@types/jest": "^29.5.1",
         "@types/json-stable-stringify": "^1.0.34",
@@ -616,6 +618,17 @@
       "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true
+    },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.7.tgz",
+      "integrity": "sha512-eoRfl9trBEt7BrQ6t3GHY/ZOcDOMBIOgqghd9qkIWMpcqQgWbU5Yf5UeHA6wwnLYpOMIJoKqazJ0cUDM79yr+g==",
+      "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1606,6 +1619,18 @@
         "lru-cache": "~9.1.1"
       }
     },
+    "node_modules/cache-manager-ioredis-yet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cache-manager-ioredis-yet/-/cache-manager-ioredis-yet-1.1.0.tgz",
+      "integrity": "sha512-bGBAq8oNzzNkO2dwlYGWBxNXrz4w8FUTpe3nfUydJ6bm1ixKEcSUKYksGokQMaRgqkQjMbIHWFkvb8p+V9ZKqw==",
+      "dependencies": {
+        "cache-manager": "^5.1.0",
+        "ioredis": "^5.2.3"
+      },
+      "engines": {
+        "node": ">= 16.17.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1792,6 +1817,14 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1863,7 +1896,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1889,6 +1921,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-newline": {
@@ -2277,6 +2317,29 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3222,6 +3285,16 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -3321,8 +3394,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3648,6 +3720,25 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -3829,6 +3920,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -4983,6 +5079,17 @@
       "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ==",
       "dev": true
     },
+    "@golevelup/ts-jest": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.7.tgz",
+      "integrity": "sha512-eoRfl9trBEt7BrQ6t3GHY/ZOcDOMBIOgqghd9qkIWMpcqQgWbU5Yf5UeHA6wwnLYpOMIJoKqazJ0cUDM79yr+g==",
+      "dev": true
+    },
+    "@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5740,6 +5847,15 @@
         "lru-cache": "~9.1.1"
       }
     },
+    "cache-manager-ioredis-yet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cache-manager-ioredis-yet/-/cache-manager-ioredis-yet-1.1.0.tgz",
+      "integrity": "sha512-bGBAq8oNzzNkO2dwlYGWBxNXrz4w8FUTpe3nfUydJ6bm1ixKEcSUKYksGokQMaRgqkQjMbIHWFkvb8p+V9ZKqw==",
+      "requires": {
+        "cache-manager": "^5.1.0",
+        "ioredis": "^5.2.3"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5862,6 +5978,11 @@
         }
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5923,7 +6044,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -5939,6 +6059,11 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
+    },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -6224,6 +6349,22 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -6945,6 +7086,16 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7020,8 +7171,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -7246,6 +7396,19 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -7376,6 +7539,11 @@
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -30,12 +30,14 @@
   "dependencies": {
     "@nestjs/common": "^9.4.0",
     "cache-manager": "^5.2.1",
+    "cache-manager-ioredis-yet": "^1.1.0",
     "json-stable-stringify": "^1.0.2",
     "lodash": "^4.17.21",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@golevelup/nestjs-testing": "^0.1.2",
+    "@golevelup/ts-jest": "^0.3.7",
     "@nestjs/testing": "^9.4.0",
     "@types/jest": "^29.5.1",
     "@types/json-stable-stringify": "^1.0.34",

--- a/package/src/cache-module-options.ts
+++ b/package/src/cache-module-options.ts
@@ -1,8 +1,34 @@
-import { MemoryConfig } from 'cache-manager';
+import { Cache, Config, MemoryConfig } from 'cache-manager';
+import { RedisClusterConfig } from 'cache-manager-ioredis-yet';
+import Redis, { Cluster, RedisOptions } from 'ioredis';
+
+export type RedisStoreConfig = (
+  | RedisOptions
+  | {
+      clusterConfig: RedisClusterConfig;
+    }
+) &
+  Config;
+
+export type CacheEngineCreationConfig =
+  | { name: string; type: 'ioredis'; config?: RedisStoreConfig }
+  | {
+      name: string;
+      type: 'ioredis-instance';
+      config: {
+        ioredisInstance: Redis | Cluster;
+        options?: Config;
+      };
+    }
+  | { name: string; type: 'memory'; config?: MemoryConfig };
 
 export type CacheModuleOptions = {
-  memoryConfig?: MemoryConfig;
   cacheModulePrefix?: string;
   cacheSeparator?: string;
-  //   type: 'memory' | 'redis'
+  createCacheEngine?: () => Promise<Cache | Cache[]>;
+  cacheEngineCreationConfigs?: CacheEngineCreationConfig[];
+  defaultMemoryCacheEngineCreationConfig?: MemoryConfig;
+  // shouldThrowAnErrorIfCacheEngineSetupFails?: boolean;
+  shouldAlwaysSetupDefaultMemoryCacheEngine?: boolean;
+  shouldSetupDefaultMemoryCacheEngineAsFallback?: boolean;
 };

--- a/package/src/constants.ts
+++ b/package/src/constants.ts
@@ -1,5 +1,6 @@
 export const CACHE_MODULE_OPTIONS: string = 'CACHE_MODULE_OPTIONS';
 export const CACHE_MANAGER_INSTANCE: string = 'CACHE_MANAGER_INSTANCE';
+export const CACHE_ENGINES: string = 'CACHE_ENGINES';
 
 export const DEFAULT_CACHE_SEPARATOR: string = ':';
 export const DEFAULT_MEMORY_CACHE_TTL_IN_MILLISECONDS: number = 15 * 60 * 1000; // 15m

--- a/package/src/decorator/cache-del.decorator.spec.ts
+++ b/package/src/decorator/cache-del.decorator.spec.ts
@@ -100,9 +100,9 @@ describe('CacheDelDecorator', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
-        CacheModule.register({
+        CacheModule.registerAsync({
           cacheModulePrefix: 'test-module',
-          memoryConfig: {
+          defaultMemoryCacheEngineCreationConfig: {
             ttl: 15 * 60 * 1000,
             max: 100,
           },

--- a/package/src/decorator/cache-wrap.decorator.spec.ts
+++ b/package/src/decorator/cache-wrap.decorator.spec.ts
@@ -78,9 +78,9 @@ describe('CacheWrapDecorator', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
-        CacheModule.register({
+        CacheModule.registerAsync({
           cacheModulePrefix: 'test-module',
-          memoryConfig: {
+          defaultMemoryCacheEngineCreationConfig: {
             ttl: 15 * 60 * 1000,
             max: 100,
           },

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -1,3 +1,5 @@
+import { Cache, MultiCache } from 'cache-manager';
+
 export type GeneratorFunction = <T>(functionArgs: T) => string;
 
 export type CacheWrapOptions = {
@@ -12,3 +14,6 @@ export type CacheDelOptions = {
   debug?: boolean;
   functionArgsSerializer?: GeneratorFunction;
 };
+
+export type CacheManager = MultiCache;
+export type CacheEngine = Cache;

--- a/package/src/utility/cache-module-provider.utility.spec.ts
+++ b/package/src/utility/cache-module-provider.utility.spec.ts
@@ -1,0 +1,951 @@
+jest.mock('cache-manager');
+jest.mock('cache-manager-ioredis-yet');
+
+const IORedis = require('ioredis');
+
+import * as cacheManager from 'cache-manager';
+import * as cacheManagerIOredisYet from 'cache-manager-ioredis-yet';
+import { createMock } from '@golevelup/ts-jest';
+import { memoryStore, MemoryStore, MemoryCache } from 'cache-manager';
+
+import * as cacheModuleProviderUtility from './cache-module-provider.utility';
+import { RedisStore, RedisCache } from 'cache-manager-ioredis-yet';
+import { CacheEngine } from '../types';
+
+describe('cache-module-provider.utility', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('createDefaultMemoryCacheEngine', () => {
+    it('should create default memory cache engine with default options', async () => {
+      jest
+        .spyOn(cacheManager, 'memoryStore')
+        .mockReturnValue(createMock<MemoryStore>());
+
+      const mockMemoryCache = createMock<MemoryCache>();
+
+      jest.spyOn(cacheManager, 'caching').mockResolvedValue(mockMemoryCache);
+
+      jest
+        .spyOn(cacheManager, 'memoryStore')
+        .mockReturnValue(createMock<MemoryStore>());
+
+      const memoryCache: MemoryCache =
+        await cacheModuleProviderUtility.createDefaultMemoryCacheEngine();
+
+      expect(memoryCache).toBe(mockMemoryCache);
+
+      expect(memoryStore).toHaveBeenCalled();
+      expect(memoryStore).toHaveBeenCalledWith({ max: 100, ttl: 900000 });
+    });
+
+    it('should create default memory cache engine override options', async () => {
+      const mockMemoryStore = createMock<MemoryStore>();
+
+      jest.spyOn(cacheManager, 'memoryStore').mockReturnValue(mockMemoryStore);
+
+      const mockMemoryCache = createMock<MemoryCache>();
+
+      jest.spyOn(cacheManager, 'caching').mockResolvedValue(mockMemoryCache);
+
+      const memoryCache: MemoryCache =
+        await cacheModuleProviderUtility.createDefaultMemoryCacheEngine({
+          ttl: 10 * 60 * 1000,
+          max: 1000,
+          allowStale: true,
+        });
+
+      expect(memoryCache).toBe(mockMemoryCache);
+
+      expect(cacheManager.memoryStore).toHaveBeenCalled();
+      expect(cacheManager.memoryStore).toHaveBeenCalledWith({
+        allowStale: true,
+        max: 1000,
+        ttl: 600000,
+      });
+
+      expect(cacheManager.caching).toHaveBeenCalled();
+      expect(cacheManager.caching).toHaveBeenCalledWith(mockMemoryStore);
+    });
+  });
+
+  describe('createCacheEngineFactory', () => {
+    describe('memory', () => {
+      it('should create memory cache engine', async () => {
+        const mockMemoryStore = createMock<MemoryStore>();
+
+        jest
+          .spyOn(cacheManager, 'memoryStore')
+          .mockReturnValue(mockMemoryStore);
+
+        const mockMemoryCache = createMock<MemoryCache>();
+
+        jest.spyOn(cacheManager, 'caching').mockResolvedValue(mockMemoryCache);
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngineFactory({
+            name: 'a memory cache engine name',
+            type: 'memory',
+            config: {
+              ttl: 5 * 60 * 1000,
+              max: 1000,
+            },
+          }),
+        ).resolves.toBe(mockMemoryCache);
+
+        expect(cacheManager.memoryStore).toHaveBeenCalled();
+        expect(cacheManager.memoryStore).toHaveBeenCalledWith({
+          max: 1000,
+          ttl: 300000,
+        });
+
+        expect(cacheManager.caching).toHaveBeenCalled();
+        expect(cacheManager.caching).toHaveBeenCalledWith(mockMemoryStore);
+      });
+
+      it('should not throw if failed to create memory cache engine', async () => {
+        const mockMemoryStore = createMock<MemoryStore>();
+
+        jest
+          .spyOn(cacheManager, 'memoryStore')
+          .mockReturnValue(mockMemoryStore);
+
+        jest
+          .spyOn(cacheManager, 'caching')
+          .mockRejectedValue(new Error('an caching error'));
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngineFactory({
+            name: 'a memory cache engine name',
+            type: 'memory',
+            config: {
+              ttl: 5 * 60 * 1000,
+              max: 1000,
+            },
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(cacheManager.memoryStore).toHaveBeenCalled();
+        expect(cacheManager.memoryStore).toHaveBeenCalledWith({
+          max: 1000,
+          ttl: 300000,
+        });
+
+        expect(cacheManager.caching).toHaveBeenCalled();
+        expect(cacheManager.caching).toHaveBeenCalledWith(mockMemoryStore);
+      });
+    });
+
+    describe('ioredis', () => {
+      it('should create ioredis cache engine', async () => {
+        const mockRedisStore = createMock<RedisStore>();
+
+        jest
+          .spyOn(cacheManagerIOredisYet, 'redisStore')
+          .mockResolvedValue(mockRedisStore);
+
+        const mockRedisCache = createMock<RedisCache>();
+
+        jest.spyOn(cacheManager, 'caching').mockResolvedValue(mockRedisCache);
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngineFactory({
+            name: 'a ioredis cache engine name',
+            type: 'ioredis',
+            config: {
+              db: 0,
+              host: 'localhost',
+              port: 6378,
+            },
+          }),
+        ).resolves.toBe(mockRedisCache);
+
+        expect(cacheManagerIOredisYet.redisStore).toHaveBeenCalled();
+        expect(cacheManagerIOredisYet.redisStore).toHaveBeenCalledWith({
+          db: 0,
+          host: 'localhost',
+          port: 6378,
+        });
+
+        expect(cacheManager.caching).toHaveBeenCalled();
+        expect(cacheManager.caching).toHaveBeenCalledWith(mockRedisStore);
+      });
+
+      it('should not throw if failed to create ioredis cache engine', async () => {
+        const mockRedisStore = createMock<RedisStore>();
+
+        jest
+          .spyOn(cacheManagerIOredisYet, 'redisStore')
+          .mockResolvedValue(mockRedisStore);
+
+        jest
+          .spyOn(cacheManager, 'caching')
+          .mockRejectedValue(new Error('an caching error'));
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngineFactory({
+            name: 'a ioredis cache engine name',
+            type: 'ioredis',
+            config: {
+              db: 0,
+              host: 'localhost',
+              port: 6378,
+            },
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(cacheManagerIOredisYet.redisStore).toHaveBeenCalled();
+        expect(cacheManagerIOredisYet.redisStore).toHaveBeenCalledWith({
+          db: 0,
+          host: 'localhost',
+          port: 6378,
+        });
+
+        expect(cacheManager.caching).toHaveBeenCalled();
+        expect(cacheManager.caching).toHaveBeenCalledWith(mockRedisStore);
+      });
+    });
+
+    describe('ioredis-instance', () => {
+      it('should create ioredis cache engine with an exist ioredis instance', async () => {
+        const mockRedisStore = createMock<RedisStore>();
+
+        jest
+          .spyOn(cacheManagerIOredisYet, 'redisInsStore')
+          .mockReturnValue(mockRedisStore);
+
+        const mockRedisCache = createMock<RedisCache>();
+
+        jest.spyOn(cacheManager, 'caching').mockResolvedValue(mockRedisCache);
+
+        const mockIoRedisInstance = createMock<typeof IORedis>();
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngineFactory({
+            name: 'a ioredis cache engine name',
+            type: 'ioredis-instance',
+            config: {
+              ioredisInstance: mockIoRedisInstance,
+              options: {
+                ttl: 10 * 60 * 1000,
+              },
+            },
+          }),
+        ).resolves.toBe(mockRedisCache);
+
+        expect(cacheManagerIOredisYet.redisInsStore).toHaveBeenCalled();
+        expect(cacheManagerIOredisYet.redisInsStore).toHaveBeenCalledWith(
+          mockIoRedisInstance,
+          {
+            ttl: 10 * 60 * 1000,
+          },
+        );
+
+        expect(cacheManager.caching).toHaveBeenCalled();
+        expect(cacheManager.caching).toHaveBeenCalledWith(mockRedisStore);
+      });
+
+      it('should not throw if failed to create cache engine', async () => {
+        const mockRedisStore = createMock<RedisStore>();
+
+        jest
+          .spyOn(cacheManagerIOredisYet, 'redisInsStore')
+          .mockReturnValue(mockRedisStore);
+
+        jest
+          .spyOn(cacheManager, 'caching')
+          .mockRejectedValue(new Error('an caching error'));
+
+        const mockIoRedisInstance = createMock<typeof IORedis>();
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngineFactory({
+            name: 'a ioredis cache engine name',
+            type: 'ioredis-instance',
+            config: {
+              ioredisInstance: mockIoRedisInstance,
+              options: {
+                ttl: 10 * 60 * 1000,
+              },
+            },
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(cacheManagerIOredisYet.redisInsStore).toHaveBeenCalled();
+        expect(cacheManagerIOredisYet.redisInsStore).toHaveBeenCalledWith(
+          mockIoRedisInstance,
+          {
+            ttl: 10 * 60 * 1000,
+          },
+        );
+
+        expect(cacheManager.caching).toHaveBeenCalled();
+        expect(cacheManager.caching).toHaveBeenCalledWith(mockRedisStore);
+      });
+    });
+  });
+
+  describe('createCacheEngines', () => {
+    describe('when `options.cacheEngineCreationConfigs` is provided', () => {
+      it('should return cache engines based on `cacheEngineCreationConfigs`', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+        const mockRedisCacheEngine = createMock<RedisCache>();
+
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(mockMemoryCacheEngine)
+          .mockResolvedValueOnce(mockRedisCacheEngine);
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+              },
+              {
+                name: 'b name',
+                type: 'ioredis',
+                config: {
+                  db: 0,
+                  host: 'localhost',
+                  port: 6378,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([mockMemoryCacheEngine, mockRedisCacheEngine]),
+        );
+
+        expect(cacheEngines.length).toEqual(2);
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toBeCalledTimes(2);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, { name: 'a name', type: 'memory' });
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(2, {
+          config: { db: 0, host: 'localhost', port: 6378 },
+          name: 'b name',
+          type: 'ioredis',
+        });
+      });
+
+      it('when one of cache engines failed to create should return the other cache engines based on `cacheEngineCreationConfigs`', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(mockMemoryCacheEngine)
+          .mockResolvedValueOnce(undefined); // try catch inside `createCacheEngineFactory`
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+              },
+              {
+                name: 'b name',
+                type: 'ioredis',
+                config: {
+                  db: 0,
+                  host: 'localhost',
+                  port: 6378,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual([mockMemoryCacheEngine]);
+
+        expect(cacheEngines.length).toEqual(1);
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toBeCalledTimes(2);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, { name: 'a name', type: 'memory' });
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(2, {
+          config: { db: 0, host: 'localhost', port: 6378 },
+          name: 'b name',
+          type: 'ioredis',
+        });
+      });
+
+      it('when all of cache engines failed to create should return default memory cache engine', async () => {
+        const mockDefaultMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createDefaultMemoryCacheEngine')
+          .mockResolvedValue(mockDefaultMemoryCacheEngine);
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(undefined) // try catch inside `createCacheEngineFactory`
+          .mockResolvedValueOnce(undefined); // try catch inside `createCacheEngineFactory`
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+              },
+              {
+                name: 'b name',
+                type: 'ioredis',
+                config: {
+                  db: 0,
+                  host: 'localhost',
+                  port: 6378,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual([mockDefaultMemoryCacheEngine]);
+
+        expect(cacheEngines.length).toEqual(1);
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toBeCalledTimes(2);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, { name: 'a name', type: 'memory' });
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(2, {
+          config: { db: 0, host: 'localhost', port: 6378 },
+          name: 'b name',
+          type: 'ioredis',
+        });
+      });
+    });
+
+    describe('when `options.shouldSetupDefaultMemoryCacheEngineAsFallback` is provided', () => {
+      it('when `shouldSetupDefaultMemoryCacheEngineAsFallback = true` should create default memory cache engine', async () => {
+        const mockDefaultMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createDefaultMemoryCacheEngine')
+          .mockResolvedValue(mockDefaultMemoryCacheEngine);
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(undefined); // due to try catch inside
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngines({
+            shouldSetupDefaultMemoryCacheEngineAsFallback: true,
+            createCacheEngine: async () => {
+              throw new Error('an error');
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 5 * 60 * 100,
+                },
+              },
+            ],
+          }),
+        ).resolves.toEqual([mockDefaultMemoryCacheEngine]);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 30000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).toHaveBeenCalled();
+      });
+
+      it('when `shouldSetupDefaultMemoryCacheEngineAsFallback = false` should not create default memory cache engine', async () => {
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(undefined); // due to try catch inside
+
+        await expect(
+          cacheModuleProviderUtility.createCacheEngines({
+            shouldSetupDefaultMemoryCacheEngineAsFallback: false,
+            createCacheEngine: async () => {
+              throw new Error('an error');
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 5 * 60 * 100,
+                },
+              },
+            ],
+          }),
+        ).rejects.toThrowError(new Error('Cache engines has not setup'));
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 30000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when `options.shouldAlwaysSetupDefaultMemoryCacheEngine` is provided', () => {
+      it('when `options.shouldAlwaysSetupDefaultMemoryCacheEngine` is true should return cache engines including default memory cache engines', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+        const mockDefaultMemoryCacheEngine = createMock<MemoryCache>();
+        const mocRedisCacheEngine = createMock<RedisCache>();
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createDefaultMemoryCacheEngine')
+          .mockResolvedValue(mockDefaultMemoryCacheEngine);
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(mockMemoryCacheEngine);
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            shouldAlwaysSetupDefaultMemoryCacheEngine: true,
+            createCacheEngine: async () => {
+              return [mocRedisCacheEngine];
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 5 * 60 * 100,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([
+            mockMemoryCacheEngine,
+            mocRedisCacheEngine,
+            mockDefaultMemoryCacheEngine,
+          ]),
+        );
+
+        expect(cacheEngines.length).toEqual(3);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 30000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).toHaveBeenCalled();
+      });
+    });
+
+    describe('when `options.createCacheEngines` and `options.cacheEngineCreationConfigs` creator function is provided', () => {
+      it('when `createCacheEngines` creator function and one of cache engines create based on `cacheEngineCreationConfigs` throw an error should return cache engines created based on `cacheEngineCreationConfigs`', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValueOnce(undefined) // this due to try catch inside
+          .mockResolvedValueOnce(mockMemoryCacheEngine);
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            createCacheEngine: async () => {
+              throw new Error('an error');
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 5 * 60 * 100,
+                },
+              },
+              {
+                name: 'b name',
+                type: 'memory',
+                config: {
+                  ttl: 10 * 60 * 100,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([mockMemoryCacheEngine]),
+        );
+
+        expect(cacheEngines.length).toEqual(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(2);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 30000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(2, {
+          config: { ttl: 60000 },
+          name: 'b name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('when `createCacheEngines` creator function and all of cache engines create based on `cacheEngineCreationConfigs` throw an error should return default memory cache engine', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createDefaultMemoryCacheEngine')
+          .mockResolvedValue(mockMemoryCacheEngine);
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValue(undefined); // this due to try catch inside
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            createCacheEngine: async () => {
+              throw new Error('an error');
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 10 * 60 * 100,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([mockMemoryCacheEngine]),
+        );
+
+        expect(cacheEngines.length).toEqual(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 60000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).toHaveBeenCalled();
+      });
+
+      it('when `createCacheEngines` throw an error should return cache engines create based on `cacheEngineCreationConfigs` as normal', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValue(mockMemoryCacheEngine);
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            createCacheEngine: async () => {
+              throw new Error('an error');
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 10 * 60 * 100,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([mockMemoryCacheEngine]),
+        );
+
+        expect(cacheEngines.length).toEqual(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 60000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should return cache engines returned from `createCacheEngines` creator function and create based on `cacheEngineCreationConfigs`', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+        const mockRedisCacheEngine = createMock<RedisCache>();
+
+        const mockMemoryCacheEngine2 = createMock<MemoryCache>();
+
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createCacheEngineFactory')
+          .mockResolvedValue(mockMemoryCacheEngine2);
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            createCacheEngine: async () => {
+              return [mockMemoryCacheEngine, mockRedisCacheEngine];
+            },
+            cacheEngineCreationConfigs: [
+              {
+                name: 'a name',
+                type: 'memory',
+                config: {
+                  ttl: 10 * 60 * 100,
+                },
+              },
+            ],
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([
+            mockMemoryCacheEngine,
+            mockRedisCacheEngine,
+            mockMemoryCacheEngine2,
+          ]),
+        );
+
+        expect(cacheEngines.length).toEqual(3);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalled();
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          cacheModuleProviderUtility.createCacheEngineFactory,
+        ).toHaveBeenNthCalledWith(1, {
+          config: { ttl: 60000 },
+          name: 'a name',
+          type: 'memory',
+        });
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when `options.createCacheEngines` creator function is provided', () => {
+      it('should return cache engines returned from `createCacheEngines` creator function', async () => {
+        const mockMemoryCacheEngine = createMock<MemoryCache>();
+        const mockRedisCacheEngine = createMock<RedisCache>();
+
+        jest.spyOn(
+          cacheModuleProviderUtility,
+          'createDefaultMemoryCacheEngine',
+        );
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            createCacheEngine: async () => {
+              return [mockMemoryCacheEngine, mockRedisCacheEngine];
+            },
+          });
+
+        expect(cacheEngines).toEqual(
+          expect.arrayContaining([mockMemoryCacheEngine, mockRedisCacheEngine]),
+        );
+
+        expect(cacheEngines.length).toEqual(2);
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should return default memory cache engines if provided `createCacheEngines` creator function throw an error', async () => {
+        const mockDefaultMemoryCacheEngine = createMock<MemoryCache>();
+
+        jest
+          .spyOn(cacheModuleProviderUtility, 'createDefaultMemoryCacheEngine')
+          .mockResolvedValue(mockDefaultMemoryCacheEngine);
+
+        const cacheEngines: CacheEngine[] =
+          await cacheModuleProviderUtility.createCacheEngines({
+            createCacheEngine: async () => {
+              throw new Error('an error');
+            },
+          });
+
+        expect(cacheEngines).toEqual([mockDefaultMemoryCacheEngine]);
+
+        expect(cacheEngines.length).toEqual(1);
+
+        expect(
+          cacheModuleProviderUtility.createDefaultMemoryCacheEngine,
+        ).toHaveBeenCalled();
+      });
+    });
+
+    it('when `options` is not provided should return memory cache engine as default cache engine', async () => {
+      const mockDefaultMemoryCacheEngine = createMock<MemoryCache>();
+
+      jest
+        .spyOn(cacheModuleProviderUtility, 'createDefaultMemoryCacheEngine')
+        .mockResolvedValue(mockDefaultMemoryCacheEngine);
+
+      const cacheEngines: CacheEngine[] =
+        await cacheModuleProviderUtility.createCacheEngines();
+
+      expect(cacheEngines).toEqual([mockDefaultMemoryCacheEngine]);
+      expect(cacheEngines.length).toEqual(1);
+    });
+  });
+});

--- a/package/src/utility/cache-module-provider.utility.ts
+++ b/package/src/utility/cache-module-provider.utility.ts
@@ -1,0 +1,145 @@
+import {
+  MemoryConfig,
+  MemoryCache,
+  MemoryStore,
+  memoryStore,
+  caching,
+} from 'cache-manager';
+import {
+  DEFAULT_MEMORY_CACHE_MAX,
+  DEFAULT_MEMORY_CACHE_TTL_IN_MILLISECONDS,
+} from '../constants';
+import { Logger } from '@nestjs/common';
+import {
+  RedisStore,
+  redisStore,
+  redisInsStore,
+} from 'cache-manager-ioredis-yet';
+import _ from 'lodash';
+import {
+  CacheEngineCreationConfig,
+  CacheModuleOptions,
+} from '../cache-module-options';
+import { CacheEngine } from '../types';
+
+export const createDefaultMemoryCacheEngine = async (
+  memoryConfig?: MemoryConfig,
+): Promise<MemoryCache> => {
+  const mStore: MemoryStore = memoryStore({
+    max: DEFAULT_MEMORY_CACHE_MAX,
+    ttl: DEFAULT_MEMORY_CACHE_TTL_IN_MILLISECONDS,
+    ...(memoryConfig ?? {}),
+  });
+
+  const memoryCacheEngine: MemoryCache = await caching(mStore);
+
+  return memoryCacheEngine;
+};
+
+export const createCacheEngineFactory = async (
+  cacheEngineCreationConfig: CacheEngineCreationConfig,
+): Promise<CacheEngine | undefined> => {
+  try {
+    if (cacheEngineCreationConfig.type === 'memory') {
+      const mStore: MemoryStore = memoryStore(cacheEngineCreationConfig.config);
+
+      return await caching(mStore);
+    }
+
+    if (cacheEngineCreationConfig.type === 'ioredis') {
+      const rStore: RedisStore = await redisStore(
+        cacheEngineCreationConfig.config,
+      );
+
+      return await caching(rStore);
+    }
+
+    if (cacheEngineCreationConfig.type === 'ioredis-instance') {
+      const rInsStore: RedisStore = redisInsStore(
+        cacheEngineCreationConfig.config.ioredisInstance,
+        cacheEngineCreationConfig.config.options,
+      );
+
+      return await caching(rInsStore);
+    }
+  } catch (error) {
+    Logger.error({
+      message:
+        'Create Cache Engine Error from `options.cacheEngineCreationConfig`',
+      cacheEngineCreationConfig,
+      error: {
+        message: _.get(error, 'message'),
+        stack: _.get(error, 'stack'),
+      },
+    });
+  }
+
+  return undefined;
+};
+
+export const createCacheEngines = async (
+  options?: CacheModuleOptions,
+): Promise<CacheEngine[]> => {
+  const totalCacheEngines: CacheEngine[] = [];
+
+  if (options?.createCacheEngine) {
+    const createCacheEngine: () => Promise<CacheEngine | CacheEngine[]> =
+      options.createCacheEngine;
+
+    try {
+      const cacheEngines: CacheEngine | CacheEngine[] =
+        await createCacheEngine();
+
+      totalCacheEngines.push(..._.concat(cacheEngines));
+    } catch (error) {
+      Logger.error({
+        message: 'Create Cache Engine Error from `options.createCacheEngine`',
+        createCacheEngine: options.createCacheEngine,
+        error: {
+          message: _.get(error, 'message'),
+          stack: _.get(error, 'stack'),
+        },
+      });
+    }
+  }
+
+  if (options?.cacheEngineCreationConfigs) {
+    const promises: Promise<CacheEngine | undefined>[] =
+      options.cacheEngineCreationConfigs.map(
+        async (cacheEngineCreationConfig): Promise<CacheEngine | undefined> =>
+          createCacheEngineFactory(cacheEngineCreationConfig),
+      );
+
+    const cacheEngines: (CacheEngine | undefined)[] = await Promise.all(
+      promises,
+    );
+    const compactedCacheEngines: CacheEngine[] = _.compact(cacheEngines);
+
+    totalCacheEngines.push(...compactedCacheEngines);
+  }
+
+  const shouldAlwaysSetupDefaultMemoryCacheEngine =
+    options?.shouldAlwaysSetupDefaultMemoryCacheEngine ?? false;
+
+  const shouldSetupDefaultMemoryCacheEngineAsFallback =
+    options?.shouldSetupDefaultMemoryCacheEngineAsFallback ?? true;
+
+  const hasNotSetupCacheEngines: boolean =
+    _.isEmpty(totalCacheEngines) &&
+    shouldSetupDefaultMemoryCacheEngineAsFallback;
+
+  if (hasNotSetupCacheEngines || shouldAlwaysSetupDefaultMemoryCacheEngine) {
+    const defaultMemoryCacheEngine: MemoryCache =
+      await createDefaultMemoryCacheEngine(
+        options?.defaultMemoryCacheEngineCreationConfig,
+      );
+
+    totalCacheEngines.push(defaultMemoryCacheEngine);
+  }
+
+  if (_.isEmpty(totalCacheEngines)) {
+    throw new Error('Cache engines has not setup');
+  }
+
+  return totalCacheEngines;
+};


### PR DESCRIPTION
### What does this PR do?
allow this project support difference cache engines:
- ioredis cache engine
- memory cache engine
- redis cache engine
- mysql cache engine
- postgresql cache engine
- mongodb cache engine
- sqlite cache engine
- ....

### Why are we doing this?

### How can this be tested?

### Any background context you want to provide?

### What are the relevant issues?

### Screenshots (if appropriate)
